### PR TITLE
Remove explicit baseline, add support for 'strike' property (Fix #5)

### DIFF
--- a/js/pdfTextbox.js
+++ b/js/pdfTextbox.js
@@ -56,9 +56,9 @@ function drawTextLinesOnPDF(lines, width, posX, posY, defaultStyle, doc) {
         .text(textPart.text, xPosition, yPosition, {
           link: textPart.link,
           align: "left",
-          baseline: "alphabetic",
           oblique: textPart.oblique,
-          strike: textPart.underline,
+          underline: textPart.underline,
+          strike: textPart.strike
         });
       xPosition += textPart.width;
     });


### PR DESCRIPTION
Oddly, the simple fact of removing `baseline: alphabetic` seems to have fixed the underline line being misaligned (and I'd imagine it would also fix the link problem).

As a side-effect, I added the option for textparts to have a strike property, because why not.

Let me know if I'm missing something (which I'd imagine I probably am?)